### PR TITLE
Bugfixes and Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ xMIL: Insightful Explanations for Multiple Instance Learning in Histopathology
 
 <details>
 <summary>
-  <b>xMIL: Insightful Explanations for Multiple Instance Learning in Histopathology</b>, arXiv, 2024.
+  <b>xMIL: Insightful Explanations for Multiple Instance Learning in Histopathology</b>. NeurIPS 2024.
   <br><em>Julius Hense*, Mina Jamshidi Idaji*, Oliver Eberle, Thomas Schnake, Jonas Dippel, Laure Ciernik, 
 Oliver Buchstab, Andreas Mock, Frederick Klauschen, Klaus-Robert Müller </em></br>
 * Equal contribution
 
-Accepted as a poster presentation at NeurIPS2024
+Accepted as a poster presentation at NeurIPS 2024.
 
 Open Review: https://openreview.net/forum?id=Y1fPxGevQj
 
@@ -24,7 +24,7 @@ Open Review: https://openreview.net/forum?id=Y1fPxGevQj
 @inproceedings{
 hense2024xmil,
 title={x{MIL}: Insightful Explanations for Multiple Instance Learning in Histopathology},
-author={Julius Hense and Mina Jamshidi Idaji and Oliver Eberle and Thomas Schnake and Jonas Dippel and Laure Ciernik and Oliver Buchstab and Andreas Mock and Frederick Klauschen and Klaus Robert Muller},
+author={Julius Hense and Mina Jamshidi Idaji and Oliver Eberle and Thomas Schnake and Jonas Dippel and Laure Ciernik and Oliver Buchstab and Andreas Mock and Frederick Klauschen and Klaus Robert M{\"u}ller},
 booktitle={The Thirty-eighth Annual Conference on Neural Information Processing Systems},
 year={2024},
 url={https://openreview.net/forum?id=Y1fPxGevQj}
@@ -137,7 +137,7 @@ If you find our codes useful in your work, please cite us:
 @inproceedings{
 hense2024xmil,
 title={x{MIL}: Insightful Explanations for Multiple Instance Learning in Histopathology},
-author={Julius Hense and Mina Jamshidi Idaji and Oliver Eberle and Thomas Schnake and Jonas Dippel and Laure Ciernik and Oliver Buchstab and Andreas Mock and Frederick Klauschen and Klaus Robert Muller},
+author={Julius Hense and Mina Jamshidi Idaji and Oliver Eberle and Thomas Schnake and Jonas Dippel and Laure Ciernik and Oliver Buchstab and Andreas Mock and Frederick Klauschen and Klaus Robert M{\"u}ller},
 booktitle={The Thirty-eighth Annual Conference on Neural Information Processing Systems},
 year={2024},
 url={https://openreview.net/forum?id=Y1fPxGevQj}

--- a/datasets/mil.py
+++ b/datasets/mil.py
@@ -46,7 +46,7 @@ class MILSlideDataset(Dataset):
                            min_bag_size <= len(self.patch_ids[idx]) <= max_bag_size]
             print(f"Dropping {len(self.split_metadata) - len(keep_slides)} slides with more than {max_bag_size} "
                   f"or fewer than {min_bag_size} patches.")
-            self.split_metadata = self.split_metadata.loc[keep_slides].reset_index(drop=True)
+            self.split_metadata = self.split_metadata.iloc[keep_slides].reset_index(drop=True)
             self.feature_indices = [self.feature_indices[idx] for idx in keep_slides]
             self.patch_ids = [self.patch_ids[idx] for idx in keep_slides]
         if preload_features:
@@ -97,9 +97,9 @@ class MILSlideDataset(Dataset):
         """
         idx = idx // self.num_repetitions
         # Load relevant metadata
-        source_id, slide_id = self.split_metadata.loc[idx, ['source_id', 'slide_id']]
+        source_id, slide_id = self.split_metadata.iloc[idx][['source_id', 'slide_id']]
         patch_ids = self.patch_ids[idx]
-        targets = torch.tensor(self.split_metadata.loc[idx, self.label_cols])
+        targets = torch.tensor(self.split_metadata.iloc[idx][self.label_cols].values.astype(int))
         # Load (filtered) features
         if self.features is None:
             features_path = os.path.join(self.features_dirs[source_id], slide_id)

--- a/models/model_factory.py
+++ b/models/model_factory.py
@@ -91,7 +91,6 @@ class xModelFactory:
                 discard_ratio=explanation_args.get('discard_ratio', 0),
                 attention_layer=explanation_args.get('attention_layer', None),
                 head_fusion=explanation_args.get('head_fusion', 'mean'),
-                detach_attn=explanation_args.get('detach_attn', True),
                 detach_norm=explanation_args.get('detach_norm', None),
                 detach_mean=explanation_args.get('detach_mean', False),
                 detach_pe=explanation_args.get('detach_pe', False)

--- a/scripts/train_attnmil_template.sh
+++ b/scripts/train_attnmil_template.sh
@@ -40,6 +40,7 @@ python3 train.py \
 --objective cross-entropy \
 --num-epochs 1000 \
 --val-interval 1 \
+--stop-criterion auc \
 \
 --test-checkpoint best \
 \

--- a/scripts/train_transmil_template.sh
+++ b/scripts/train_transmil_template.sh
@@ -43,6 +43,7 @@ python3 train.py \
 --objective cross-entropy \
 --num-epochs 200 \
 --val-interval 1 \
+--stop-criterion auc \
 \
 --test-checkpoint best \
 \

--- a/toy_experiments/models.py
+++ b/toy_experiments/models.py
@@ -95,7 +95,6 @@ def get_xmodel(model_type, explanation_type, model, detach_pe=False):
             discard_ratio=0,
             attention_layer=None,
             head_fusion='mean',
-            detach_attn=True,
             detach_norm=None,
             detach_mean=False,
             detach_pe=detach_pe

--- a/train.py
+++ b/train.py
@@ -84,6 +84,7 @@ def get_args():
     parser.add_argument('--num-epochs', type=int, default=100)
     parser.add_argument('--val-interval', type=int, default=1)
     parser.add_argument('--early-stopping', action='store_true')
+    parser.add_argument('--stop-criterion', type=str, default='loss')
     parser.add_argument('--optimizer', type=str, default='SGD')
     parser.add_argument('--grad-clip', type=float, default=None)
 
@@ -124,7 +125,7 @@ def main(args=None):
     # Set up callback
     callback = Callback(
         schedule_lr=args.schedule_lr, checkpoint_epoch=args.val_interval, path_checkpoints=save_dir,
-        early_stop=args.early_stopping)
+        stop_criterion=args.stop_criterion, early_stop=args.early_stopping)
 
     # Run training
     print("Model training")

--- a/training/callback.py
+++ b/training/callback.py
@@ -90,7 +90,7 @@ class Callback:
             torch.save(performance, name_save)
 
         if return_args:
-            return performance
+            return performance, best_model
 
     def get_best_model(self,
                        best_model,

--- a/training/loops.py
+++ b/training/loops.py
@@ -31,7 +31,7 @@ def train_classification_model(
     best_model = callback.get_model_dict(model_state_dict=model.state_dict(),
                                          optimizer_state_dict=optimizer.state_dict(),
                                          i_epoch=-1,
-                                         loss_val=np.Inf,
+                                         loss_val=np.inf,
                                          auc_val=_get_empty_auc_dict(label_cols))
     # endregion
 
@@ -126,9 +126,11 @@ def train_classification_model(
 
         # region save checkpoint and check early stopping ---------------------------
         if not i_epoch % callback.checkpoint_epoch:
-            callback.save_checkpoint(i_epoch, auc_all_train, auc_all_val, loss_all_train, loss_all_val,
-                                     auc_epoch_train, auc_epoch_val, loss_epoch_train, loss_epoch_val,
-                                     optimizer.state_dict(), model.state_dict(), best_model)
+            _, best_model = callback.save_checkpoint(
+                i_epoch, auc_all_train, auc_all_val, loss_all_train, loss_all_val,
+                auc_epoch_train, auc_epoch_val, loss_epoch_train, loss_epoch_val,
+                optimizer.state_dict(), model.state_dict(), best_model,
+                return_args=True)
             callback.early_stopping(i_epoch)
         if callback.stop:
             break
@@ -137,10 +139,11 @@ def train_classification_model(
     # region save checkpoint  ---------------------------
     performance = None
     if n_epochs:
-        performance = callback.save_checkpoint(n_epochs - 1, auc_all_train, auc_all_val, loss_all_train, loss_all_val,
-                                               auc_epoch_train, auc_epoch_val, loss_epoch_train, loss_epoch_val,
-                                               optimizer.state_dict(), model.state_dict(), best_model, last_model=True,
-                                               return_args=True)
+        performance, best_model = callback.save_checkpoint(
+            n_epochs - 1, auc_all_train, auc_all_val, loss_all_train, loss_all_val,
+            auc_epoch_train, auc_epoch_val, loss_epoch_train, loss_epoch_val,
+            optimizer.state_dict(), model.state_dict(), best_model, last_model=True,
+            return_args=True)
 
     # endregion
 


### PR DESCRIPTION
- Fixed best model saving and added `stop_criterion` to train args.
- Computing nystrom attention in transmil more efficiently.
- Updated `.loc` to `.iloc` for pandas data frames in `mil_datasets`.
- Updated bibtex.
- Tested via successfully running a toy experiment with TransMIL incl. computation of attention rollout and a TransMIL training on NSCLC incl. best model checkpoint saving.